### PR TITLE
[WIP] LDC: Upgrade Azure CI Windows image to VS 2019

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -12,13 +12,13 @@ steps:
     echo on
     cd ..
     :: Download & extract Ninja
-    curl -L -o ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip
+    curl -L -o ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip 2>&1
     mkdir ninja
     cd ninja
     7z x ../ninja.zip > nul
     cd ..
     :: Download & install clang
-    curl -L -o clang.exe https://github.com/llvm/llvm-project/releases/download/llvmorg-%CLANG_VERSION%/LLVM-%CLANG_VERSION%-win64.exe
+    curl -L -o clang.exe https://github.com/llvm/llvm-project/releases/download/llvmorg-%CLANG_VERSION%/LLVM-%CLANG_VERSION%-win64.exe 2>&1
     clang.exe /S
   displayName: Install prerequisites
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,10 @@ jobs:
 - job: Windows
   timeoutInMinutes: 180
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   variables:
     CLANG_VERSION: 8.0.1
-    VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+    VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
     EXTRA_CMAKE_FLAGS: -DLLVM_USE_CRT_RELEASE=MT
   strategy:
     matrix:


### PR DESCRIPTION
Doesn't work yet, at least with clang v8.0.0 as host compiler (`llvm-tblgen.exe: Unknown command line argument '-gen-intrinsic-impl'` etc.); will retry with clang v8.0.1 once available.